### PR TITLE
Add SigmaCV to Career

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Sorted alphabetically into sub-categories.
 - [JOB INTERVIEW](https://twitter.com/birchlse/status/1491006458993209352?s=20&t=9Zfcge_IfN5hzMf7Dt9Pxw): Jonathan Birch gives some helpful tips on how to navigate tenure-track job talks.
 - [PHD COMPETENCE MODEL](https://phdcompetencemodel.nl/): This is "a self-assessment tool to help PhD candidates more efficiently direct their time towards improving skills areas that are most needed for their own personal career development."
 - [POSTDOC FUNDING](https://research.jhu.edu/rdt/funding-opportunities/postdoctoral/): Find a list of postdoctoral funding opportunities (there are also separate lists for neuroscience/neurology and cancer/oncology).
+- [SIGMACV](https://sigmacv.org): A free, open-source tool that auto-builds your academic CV from ORCID and OpenAlex — curate it and export to PDF, Word, LaTeX or Markdown, or publish a living public page.
 - [TALK INVITATIONS](https://www.chjh.nl/what-to-do-with-that-invitation/): Have you been invited to speak somewhere? Here are some questions you might (and should) ask beforehand.
 
 ### Crediting


### PR DESCRIPTION
Adds **SigmaCV** to the **Career** section.

SigmaCV is a free, open-source web app that auto-builds an academic CV from the open research record (ORCID, OpenAlex, Crossref, and more) — handy for PhD students and researchers assembling CVs for job, grant, and fellowship applications. It matches your work by identifier (ORCID / OpenAlex ID, never by name), formats citations consistently, and exports to PDF, Word, LaTeX or Markdown — or publishes a living public page that re-syncs.

- Website: https://sigmacv.org
- Source (Apache-2.0): https://github.com/BasileChretien/sigmacv

Placed alphabetically within the Career list. _(Disclosure: I'm the maintainer of SigmaCV.)_
