### PR TITLE
Add Research Paper Lifecycle Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Sorted alphabetically into sub-categories.
 - [PAPAJA](http://frederikaust.com/papaja_man/introduction.html): If you want to create reproducible manuscripts including tables directly from your data in R, use the papaja package.
 - [PREPRINT TEMPLATES](https://osf.io/hsv6a/): Amazing and useful "Word templates for typesetting preprints. Because your preprint should be a #prettypreprint" and we don't have time for endless formatting.
 - [QUILLBOT](https://quillbot.com/): Paraphrase like the awesome boss you are using QuillBot.
+- [RESEARCH PAPER LIFECYCLE SKILLS](https://github.com/ShaishavMaisuria/research-paper-lifecycle-skills): Open-source Agent Skills package for literature review, citation checks, submission preflight, rebuttals, and presentation prep.
 - [THE CRAFT OF WRITING EFFECTIVELY](https://www.youtube.com/watch?v=vtIzMaLkCaM): An effort to communicate helpful rules, skills, and resources that are available to graduate students interested in further developing their writing style.
 
 ---


### PR DESCRIPTION
Adds Research Paper Lifecycle Skills to the Writing section.\n\nShort pitch: this open-source Agent Skills package gives PhD students and researchers reusable workflows for literature review, citation checks, submission preflight, rebuttals, artifacts, slides, and posters. It fits the list as a practical paper-writing and publication workflow resource, and the entry follows the existing one-resource format.